### PR TITLE
Feature/more control objects

### DIFF
--- a/Trumpf.Coparoo.Web/Controls/Checkbox.cs
+++ b/Trumpf.Coparoo.Web/Controls/Checkbox.cs
@@ -1,0 +1,34 @@
+﻿namespace Trumpf.Coparoo.Web.Controls
+{
+    using OpenQA.Selenium;
+    using OpenQA.Selenium.Interactions;
+
+    /// <summary>
+    /// Checkbox control object.
+    /// Expects an input html element with attribute type="checkbox".
+    /// </summary>
+    public class Checkbox : ControlObject
+    {
+        /// <summary>
+        /// Gets the search pattern.
+        /// </summary>
+        protected override By SearchPattern => By.XPath(".//input[@type='checkbox']");
+
+        /// <summary>
+        /// Gets or sets the checked attribute.
+        /// </summary>
+        public bool Checked
+        {
+            get { return Node.GetAttribute("checked") != null; }
+
+            set
+            {
+                if (Checked != value)
+                {
+                    var element = Parent.Node.FindElement(SearchPattern);
+                    new Actions(Root.Driver).MoveToElement(element).Click().Perform();
+                }
+            }
+        }
+    }
+}

--- a/Trumpf.Coparoo.Web/Controls/Div.cs
+++ b/Trumpf.Coparoo.Web/Controls/Div.cs
@@ -1,0 +1,15 @@
+﻿namespace Trumpf.Coparoo.Web.Controls
+{
+    using OpenQA.Selenium;
+
+    /// <summary>
+    /// Div control object.
+    /// </summary>
+    public class Div : ControlObject
+    {
+        /// <summary>
+        /// Gets the search pattern.
+        /// </summary>
+        protected override By SearchPattern => By.TagName("div");
+    }
+}

--- a/Trumpf.Coparoo.Web/Controls/Input.cs
+++ b/Trumpf.Coparoo.Web/Controls/Input.cs
@@ -1,0 +1,37 @@
+﻿namespace Trumpf.Coparoo.Web.Controls
+{
+    using OpenQA.Selenium;
+
+    /// <summary>
+    /// Text input control object.
+    /// Expects an input html element with attribute type="text".
+    /// </summary>
+    public class Input : ControlObject
+    {
+        /// <summary>
+        /// Gets the search pattern.
+        /// </summary>
+        protected override By SearchPattern => By.XPath(".//input[@type='text']");
+
+        /// <summary>
+        /// Gets or sets the text content.
+        /// </summary>
+        public string Text
+        {
+            get { return Node.GetAttribute("value"); }
+
+            set
+            {
+                if (Text != value)
+                {
+                    if (Text != string.Empty)
+                    {
+                        Node.Clear();
+                    }
+
+                    Node.SendKeys(value);
+                }
+            }
+        }
+    }
+}

--- a/Trumpf.Coparoo.Web/Controls/Label.cs
+++ b/Trumpf.Coparoo.Web/Controls/Label.cs
@@ -1,0 +1,20 @@
+﻿namespace Trumpf.Coparoo.Web.Controls
+{
+    using OpenQA.Selenium;
+
+    /// <summary>
+    /// Label control object.
+    /// </summary>
+    public class Label : ControlObject
+    {
+        /// <summary>
+        /// Gets the search pattern.
+        /// </summary>
+        protected override By SearchPattern => By.TagName("label");
+
+        /// <summary>
+        /// Gets the label text.
+        /// </summary>
+        public string Text => Node.Text;
+    }
+}

--- a/Trumpf.Coparoo.Web/Controls/Select.cs
+++ b/Trumpf.Coparoo.Web/Controls/Select.cs
@@ -1,0 +1,56 @@
+﻿namespace Trumpf.Coparoo.Web.Controls
+{
+    using System;
+
+    using OpenQA.Selenium;
+    using OpenQA.Selenium.Support.UI;
+
+    /// <summary>
+    /// Select control object.
+    /// </summary>
+    public class Select : ControlObject
+    {
+        /// <summary>
+        /// Gets the search pattern.
+        /// </summary>
+        protected override By SearchPattern => By.TagName("select");
+
+        /// <summary>
+        /// Gets the Selenium SelectElement.
+        /// </summary>
+        public SelectElement SelectElement => new SelectElement(Node);
+        
+        /// <summary>
+        /// Gets the text of the selected option.
+        /// </summary>
+        public string Text => SelectElement.SelectedOption.Text;
+
+        /// <summary>
+        /// Select all options by the text displayed. 
+        /// </summary>
+        /// <param name="text">The text of the option to be selected. If an exact match is not found, this method will perform a substring match.</param>
+        public void SelectByText(string text) => SelectElement.SelectByText(text);
+
+        /// <summary>
+        /// Gets the index of the selected option.
+        /// </summary>
+        public int Index => Int32.Parse(SelectElement.SelectedOption.GetAttribute("index"));
+
+        /// <summary>
+        /// Select the option by the index, as determined by the "index" attribute of the element. 
+        /// </summary>
+        /// <param name="index">The value of the index attribute of the option to be selected.</param>
+        public void SelectByIndex(int index) => SelectElement.SelectByIndex(index);
+
+        /// <summary>
+        /// Gets the value of the selected option.
+        /// </summary>
+        public string Value => SelectElement.SelectedOption.GetAttribute("value");
+
+        /// <summary>
+        /// Select an option by value.
+        /// </summary>
+        /// <param name="value">The value of the option to be selected.</param>
+        public void SelectByValue(string value) => SelectElement.SelectByValue(value);
+    }
+}

--- a/Trumpf.Coparoo.Web/Controls/Span.cs
+++ b/Trumpf.Coparoo.Web/Controls/Span.cs
@@ -1,0 +1,20 @@
+﻿namespace Trumpf.Coparoo.Web.Controls
+{
+    using OpenQA.Selenium;
+
+    /// <summary>
+    /// Span control object.
+    /// </summary>
+    public class Span : ControlObject
+    {
+        /// <summary>
+        /// Gets the search pattern.
+        /// </summary>
+        protected override By SearchPattern => By.TagName("span");
+
+        /// <summary>
+        /// Gets the text.
+        /// </summary>
+        public string Text => Node.Text;
+    }
+}

--- a/Trumpf.Coparoo.Web/Trumpf.Coparoo.Web.csproj
+++ b/Trumpf.Coparoo.Web/Trumpf.Coparoo.Web.csproj
@@ -26,6 +26,7 @@
 
   <!-- reference information -->
   <ItemGroup>
+    <PackageReference Include="Selenium.Support" Version="3.8.0" />
     <PackageReference Include="Selenium.WebDriver" Version="3.8.0" />
     <Reference Include="System.Windows.Forms" />
   </ItemGroup>


### PR DESCRIPTION
Added some more generic control objects. Couple of things to discuss:

1) **Checkbox.cs**
It's not sufficient to just use click() in order to check a checkbox:
https://stackoverflow.com/questions/44912203/selenium-web-driver-java-element-is-not-clickable-at-point-36-72-other-el/44916498
As a result, we use the Actions class in order to perform the click. However, it requires the underlying IWebelement object in order to initialize. Is it possible to access it other than using `Parent.Node.FindElement(SearchPattern);` ? 
`Node` doesn't work since it doesn't implement the ILocatable interface.

2) **Input.cs**
Wasn't sure how to correctly name this class. Since there are different inputs (based on their type like type="text" or type="file" etc.). Input.cs should be primarily used for text inputs (like username or password fields). How should we name it? Input.cs, InputBox.cs, InputField.cs?

3) **Select.cs**
Since Selenium offers a Select Implementation already I capsuled it within the control object. I added the Selenium.Support package to the dependencies list. 