### PR TITLE
Adds Cast<> for TabObjects

### DIFF
--- a/Trumpf.Coparoo.Web.Tests/TabObjectTests.cs
+++ b/Trumpf.Coparoo.Web.Tests/TabObjectTests.cs
@@ -1,0 +1,108 @@
+﻿// Copyright 2016, 2017, 2018 TRUMPF Werkzeugmaschinen GmbH + Co. KG.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Trumpf.Coparoo.Tests
+{
+    using NUnit.Framework;
+    using OpenQA.Selenium;
+    using Trumpf.Coparoo.Web;
+    using Trumpf.Coparoo.Web.Exceptions;
+
+    [TestFixture]
+    public class TabObjectTests : ControlTests
+    {
+        /// <summary>
+        /// Test method.
+        /// </summary>
+        [Test]
+        public void WhenCastingTabObjects_ThenTheCorrectTabObjectsAreReturned()
+        {
+            var text = Random;
+            PrepareAndExecute<Tab>(nameof(WhenCastingTabObjects_ThenTheCorrectTabObjectsAreReturned), HtmlStart + $"<button type=\"button\">{text}</button>" + HtmlEnd, tab =>
+            {
+                // Act
+                var t1 = tab.Cast<T1>();
+                var b1 = t1.On<B1>();
+                var e1 = b1.Exists.TryWaitFor();
+
+                var t2 = tab.Cast<T2>();
+                var b2 = t2.On<B2>();
+                var e2 = b2.Exists.TryWaitFor();
+
+                // Check
+                Assert.True(e1);
+                Assert.True(e2);
+            });
+        }
+
+        /// <summary>
+        /// Test method.
+        /// </summary>
+        [Test]
+        public void WhenCastingATabObjectAndThenBack_ThenTheCorrectTabObjectIsReturned()
+        {
+            var text = Random;
+            PrepareAndExecute<Tab>(nameof(WhenCastingATabObjectAndThenBack_ThenTheCorrectTabObjectIsReturned), HtmlStart + $"<button type=\"button\">{text}</button>" + HtmlEnd, tab =>
+            {
+                // Prepare
+                var t1 = tab.Cast<T1>();
+                var t2 = t1.Cast<T2>(); // cast
+                var t3 = t2.Cast<T1>(); // cast back
+
+                // Act
+                var b1 = t3.On<B1>();
+                var e1 = b1.Exists.TryWaitFor();
+
+                // Check
+                Assert.True(e1);
+            });
+        }
+
+        /// <summary>
+        /// Test method.
+        /// </summary>
+        [Test]
+        public void WhenCastingATabObject_ThenOnlyPageObjectInTheCastedPageObjectTreeCanBeAccessed()
+        {
+            // Prepare
+            var tab = new Tab();
+
+            // Act
+            var t1 = tab.Cast<T1>();
+            var t2 = tab.Cast<T2>();
+
+            // Check
+            Assert.Throws<PageObjectNotFoundException<B2>>(() => t1.On<B2>());
+            Assert.Throws<PageObjectNotFoundException<B1>>(() => t2.On<B1>());
+        }
+
+        protected class T1 : Tab
+        {
+        }
+
+        protected class T2 : Tab
+        {
+        }
+
+        protected class B1 : PageObject, IChildOf<T1>
+        {
+            protected override By SearchPattern => By.TagName("button");
+        }
+
+        protected class B2 : PageObject, IChildOf<T2>
+        {
+            protected override By SearchPattern => By.TagName("button");
+        }
+    }
+}

--- a/Trumpf.Coparoo.Web/Root/TabObject/ITabObject.cs
+++ b/Trumpf.Coparoo.Web/Root/TabObject/ITabObject.cs
@@ -68,6 +68,12 @@ namespace Trumpf.Coparoo.Web
         /// </summary>
         void Quit();
 
+        /// <summary>
+        /// Cast the tab object.
+        /// </summary>
+        /// <typeparam name="TTab">The type to cast to.</typeparam>
+        /// <returns>The tab object with the new type.</returns>
+        TTab Cast<TTab>() where TTab : ITabObject;
 
         /// <summary>
         /// Take a screen shot.

--- a/Trumpf.Coparoo.Web/Root/TabObject/TabObject.cs
+++ b/Trumpf.Coparoo.Web/Root/TabObject/TabObject.cs
@@ -35,7 +35,7 @@ namespace Trumpf.Coparoo.Web
         private readonly UIObjectInterfaceResolver objectInterfaceResolver;
         internal const string DEFAULT_FILE_PREFIX = "Coparoo";
         internal const string DEFAULT_DOT_PATH = @"C:\Program Files (x86)\Graphviz2.38\bin\dot.exe";
-        private readonly Dictionary<Type, HashSet<Type>> dyanamicParentToChildMap = new Dictionary<Type, HashSet<Type>>();
+        private Dictionary<Type, HashSet<Type>> dyanamicParentToChildMap = new Dictionary<Type, HashSet<Type>>();
 
         /// <summary>
         /// Initializes a new instance of the <see cref="TabObject"/> class.
@@ -162,6 +162,18 @@ namespace Trumpf.Coparoo.Web
                 dyanamicParentToChildMap.Add(typeof(TParentPageObject), new HashSet<Type>() { typeof(TChildPageObject) });
                 return true;
             }
+        }
+
+        /// <summary>
+        /// Cast the tab object.
+        /// </summary>
+        /// <typeparam name="TTab">The type to cast to.</typeparam>
+        /// <returns>The tab object with the new type.</returns>
+        public TTab Cast<TTab>() where TTab : ITabObject
+        {
+            var result = Resolve<TTab>();
+            result.Driver = Driver;
+            return result;
         }
 
         /// <summary>


### PR DESCRIPTION
Allows casting on ITabObject

```c#
                var t1 = tab.Cast<T1>();
                var b1 = t1.On<B1>();
                var e1 = b1.Exists.TryWaitFor();

                var t2 = tab.Cast<T2>();
                var b2 = t2.On<B2>();
                var e2 = b2.Exists.TryWaitFor();
```